### PR TITLE
rename exclude action

### DIFF
--- a/Src/Qart.Testing/TestCase.cs
+++ b/Src/Qart.Testing/TestCase.cs
@@ -121,7 +121,7 @@ namespace Qart.Testing
 
         public static void AssertContent(this TestCase testCase, XmlDocument doc, string resultName, bool rebaseline)
         {
-            string exclusionListFileName = resultName + ".xpath_exclude";
+            string exclusionListFileName = resultName + ".exclude.xpath";
             if(testCase.Contains(exclusionListFileName))
             {
                 doc.RemoveNodes(testCase.GetContent(exclusionListFileName).Split('\n').Select(_ => _.Trim()).Where(_ => !string.IsNullOrEmpty(_)));


### PR DESCRIPTION
I am looking at renaming xpath_exclude to .exclude.xpath in systemTests. 
We should also be consistent in Qart.
