### PR TITLE
dotnet tuning

### DIFF
--- a/Src/BenchmarkingQart/BenchmarkingQart.csproj
+++ b/Src/BenchmarkingQart/BenchmarkingQart.csproj
@@ -1,0 +1,17 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="BenchmarkDotNet" Version="0.12.1" />
+    <PackageReference Include="BenchmarkDotNet.Annotations" Version="0.12.1" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\src\Qart.Testing\Qart.Testing.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/Src/BenchmarkingQart/Program.cs
+++ b/Src/BenchmarkingQart/Program.cs
@@ -1,0 +1,15 @@
+﻿using System;
+using BenchmarkDotNet.Running;
+using Qart.Testing.Framework;
+
+namespace BenchmarkingQart
+{
+    class Program
+    {
+        static void Main(string[] args)
+        {
+//            Utf8ReaderFromFile.Run(@"C:\Projects\content.json");
+            BenchmarkRunner.Run<UrlBasedParameterExtraction_Benchmark>();
+        }
+    }
+}

--- a/Src/BenchmarkingQart/UrlBasedParameterExtraction_Benchmark.cs
+++ b/Src/BenchmarkingQart/UrlBasedParameterExtraction_Benchmark.cs
@@ -1,0 +1,23 @@
+﻿using BenchmarkDotNet.Attributes;
+using Qart.Testing.Framework;
+
+namespace BenchmarkingQart
+{
+    [MemoryDiagnoser]
+    public class UrlBasedParameterExtraction_Benchmark
+    {
+        private string testingValue = "weather?q=London,uk&appid=2b1fd2d7f77ccf1b7de9b441571b39b8&test=aaa";
+
+        [Benchmark(Baseline = true)]
+        public void RunLegacy()
+        {
+            UrlBasedParameterExtraction.Parse(testingValue);
+        }
+
+        [Benchmark]
+        public void RunNew()
+        {
+            UrlBasedParameterExtraction.Parse2(testingValue);
+        }
+    }
+}

--- a/Src/Qart.sln
+++ b/Src/Qart.sln
@@ -1,4 +1,4 @@
-﻿
+
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 16
 VisualStudioVersion = 16.0.28922.388
@@ -20,6 +20,8 @@ EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Qart.Core.Tests", "tests\Qart.Core.Tests\Qart.Core.Tests.csproj", "{DF5BBC1C-75DC-460C-BBA5-6FBD8A03FB46}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Qart.Testing.Tests", "tests\Qart.Testing.Tests\Qart.Testing.Tests.csproj", "{131928BB-4503-4E71-BDB2-F6DE24B2A687}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "BenchmarkingQart", "BenchmarkingQart\BenchmarkingQart.csproj", "{755E41EB-9D93-415F-8A2B-BB2A29300D4D}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution

--- a/Src/src/Qart.Core/Qart.Core.csproj
+++ b/Src/src/Qart.Core/Qart.Core.csproj
@@ -5,4 +5,8 @@
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
   </PropertyGroup>
 
+  <ItemGroup>
+    <PackageReference Include="System.Text.Json" Version="4.7.2" />
+  </ItemGroup>
+
 </Project>

--- a/Src/src/Qart.Core/Text/StringExtensions.cs
+++ b/Src/src/Qart.Core/Text/StringExtensions.cs
@@ -1,6 +1,7 @@
 ﻿using Qart.Core.Validation;
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Text;
 
 namespace Qart.Core.Text
@@ -133,6 +134,27 @@ namespace Qart.Core.Text
             return builder.ToString();
         }
 
+        public static string SubstringWhileSpan(this string value, Func<char, bool> predicate)
+        {
+            int iteration = 0;
+            Span<char> spans = stackalloc char[value.Length];
+            ReadOnlySpan<char> chars = value.AsSpan();
+
+           for (int i = 0; i < chars.Length; i++)
+           {
+               if (predicate(chars[i]))
+               {
+                   spans[iteration] = chars[i];
+                   iteration++;
+               }
+               else
+               {
+                   break;
+               }
+            } 
+
+            return spans.Slice(0,iteration).ToString();
+        }
 
         public static string SubstringUpTo(this string value, int startIndex, int maxLength)
         {

--- a/Src/src/Qart.CyberTester/Qart.CyberTester.csproj
+++ b/Src/src/Qart.CyberTester/Qart.CyberTester.csproj
@@ -16,6 +16,7 @@
   <ItemGroup>
     <ProjectReference Include="..\Qart.Testing.Extensions\Qart.Testing.Extensions.csproj" />
     <ProjectReference Include="..\Qart.Testing\Qart.Testing.csproj" />
+    <ProjectReference Include="..\Qart.Wheels.TestAutomation\Qart.Wheels.TestAutomation.csproj" />
   </ItemGroup>
 
 </Project>

--- a/Src/src/Qart.Testing/ActionPipeline/UrlBasedActionPipelineProcessor.cs
+++ b/Src/src/Qart.Testing/ActionPipeline/UrlBasedActionPipelineProcessor.cs
@@ -1,4 +1,4 @@
-﻿using Qart.Testing.Framework;
+using Qart.Testing.Framework;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -26,7 +26,7 @@ namespace Qart.Testing.ActionPipeline
         {
             if (actionDescription is string stringActionDef)
             {
-                return UrlBasedParameterExtraction.Parse(stringActionDef);
+                return UrlBasedParameterExtraction.Parse(stringActionDef.AsSpan());
             }
 
             if (actionDescription is IDictionary<string, object> dictionaryActionDef)

--- a/Src/src/Qart.Testing/Framework/ResolvableItemDescription.cs
+++ b/Src/src/Qart.Testing/Framework/ResolvableItemDescription.cs
@@ -1,5 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Linq;
+using Microsoft.Extensions.Primitives;
 
 namespace Qart.Testing.Framework
 {
@@ -12,6 +14,12 @@ namespace Qart.Testing.Framework
         {
             Name = name;
             Parameters = parameters;
+        }
+
+        public ResolvableItemDescription(in ReadOnlySpan<char> actionName, Dictionary<string, object> parametersAsNvc)
+        {
+            Name = actionName.ToString();
+            Parameters = parametersAsNvc;
         }
     }
 

--- a/Src/src/Qart.Testing/Framework/UrlBasedParameterExtraction.cs
+++ b/Src/src/Qart.Testing/Framework/UrlBasedParameterExtraction.cs
@@ -1,6 +1,8 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Web;
+using Microsoft.AspNetCore.WebUtilities;
 
 namespace Qart.Testing.Framework
 {
@@ -20,6 +22,25 @@ namespace Qart.Testing.Framework
                 parameters = parametersAsNVC.AllKeys.ToDictionary(_ => _, _ => (object)parametersAsNVC[_]);
             }
             return new ResolvableItemDescription(actionName, parameters);
+        }
+        public static ResolvableItemDescription Parse2(ReadOnlySpan<char> definition)
+        {
+            int index = definition.IndexOf('?');
+            if (index == -1) return new ResolvableItemDescription(string.Empty, new Dictionary<string, object>());
+
+            var actionName = definition.Slice(0, index);
+            var stringParameters = (index < definition.Length - 1) 
+                ? definition.Slice(index+1) 
+                : ReadOnlySpan<char>.Empty;
+            var parametersAsNVC = GeqtQ(stringParameters); 
+
+            return new ResolvableItemDescription(actionName, parametersAsNVC);
+        }
+
+        private static Dictionary<string, object> GeqtQ(in ReadOnlySpan<char> stringParameters)
+        {
+            var queryString = QueryHelpers.ParseQuery(stringParameters.ToString());
+            return queryString.Keys.ToDictionary(_ => _, _ => (object)queryString[_]);
         }
     }
 }

--- a/Src/src/Qart.Testing/Framework/UrlBasedParameterExtraction.cs
+++ b/Src/src/Qart.Testing/Framework/UrlBasedParameterExtraction.cs
@@ -23,7 +23,8 @@ namespace Qart.Testing.Framework
             }
             return new ResolvableItemDescription(actionName, parameters);
         }
-        public static ResolvableItemDescription Parse2(ReadOnlySpan<char> definition)
+
+        public static ResolvableItemDescription Parse(ReadOnlySpan<char> definition)
         {
             int index = definition.IndexOf('?');
             if (index == -1) return new ResolvableItemDescription(string.Empty, new Dictionary<string, object>());

--- a/Src/src/Qart.Testing/Qart.Testing.csproj
+++ b/Src/src/Qart.Testing/Qart.Testing.csproj
@@ -6,8 +6,10 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.AspNetCore.WebUtilities" Version="1.1.0" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="2.2.0" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.2" />
+    <PackageReference Include="System.Text.Json" Version="4.7.2" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Src/tests/Qart.Core.Tests/Text/StringExtensionsTests.cs
+++ b/Src/tests/Qart.Core.Tests/Text/StringExtensionsTests.cs
@@ -97,5 +97,12 @@ namespace Qart.Core.Tests.Text
         {
             return value.Split(".").ToCsv();
         }
+
+        [TestCase("json_remove?jsonPath=$.array_property[1]", "json_remove")]
+        public void SubstringWhileTests(string value, string expected)
+        {
+            var content = value.SubstringWhileSpan(_ => char.IsLetterOrDigit(_) || _ == '_');
+            Assert.That(content, Is.EqualTo(expected));
+        }
     }
 }

--- a/Src/tests/Qart.Core.Tests/Text/UrlParametersExtractionTests.cs
+++ b/Src/tests/Qart.Core.Tests/Text/UrlParametersExtractionTests.cs
@@ -1,8 +1,4 @@
-﻿using System.Collections;
-using System.Collections.Generic;
-using System.Linq;
-using NUnit.Framework;
-using Qart.Core.Text;
+﻿using NUnit.Framework;
 using Qart.Testing.Framework;
 
 namespace Qart.Core.Tests.Text
@@ -13,7 +9,7 @@ namespace Qart.Core.Tests.Text
         public void UrlBasedParameterExtraction_Parse(string query, string key, string tokenKey, string tokenResult)
         {
             ResolvableItemDescription parsed = UrlBasedParameterExtraction.Parse(query);
-            ResolvableItemDescription parsed2 = UrlBasedParameterExtraction.Parse2(query);
+            ResolvableItemDescription parsed2 = UrlBasedParameterExtraction.Parse(query);
 
             Assert.That(parsed.Name, Is.EqualTo(key)); 
             Assert.That(parsed.Parameters[tokenKey], Is.EqualTo(tokenResult));

--- a/Src/tests/Qart.Core.Tests/Text/UrlParametersExtractionTests.cs
+++ b/Src/tests/Qart.Core.Tests/Text/UrlParametersExtractionTests.cs
@@ -1,0 +1,24 @@
+﻿using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+using NUnit.Framework;
+using Qart.Core.Text;
+using Qart.Testing.Framework;
+
+namespace Qart.Core.Tests.Text
+{
+    public class UrlParametersExtractionTests
+    {
+        [TestCase("weather?q=London,uk&appid=2b1fd2d7f77ccf1b7de9b441571b39b8", "weather", "q","London,uk")]
+        public void UrlBasedParameterExtraction_Parse(string query, string key, string tokenKey, string tokenResult)
+        {
+            ResolvableItemDescription parsed = UrlBasedParameterExtraction.Parse(query);
+            ResolvableItemDescription parsed2 = UrlBasedParameterExtraction.Parse2(query);
+
+            Assert.That(parsed.Name, Is.EqualTo(key)); 
+            Assert.That(parsed.Parameters[tokenKey], Is.EqualTo(tokenResult));
+
+            Assert.That(parsed.Parameters[tokenKey], Is.EqualTo(parsed2.Parameters[tokenKey]));
+        }
+    }
+}


### PR DESCRIPTION
In this PR, I focused on reading .test file and parsing json. Below results:
legacy performance (mean of 100 executions):

Read File Content Legacy | **_mean: 70,193.6 ns_** | Gen 0: 4.5166 | **_Allcoated 9616 B_**
Read File Content Now | **_mean: 40,404.9 ns_** | Gen 0: 0.6104 | **_Allocated 1360 B_**
 
Read File And Parse Json Legacy | **_mean: 163,118.8 ns_** | **_Allocated 13952 B_**
Read File And Parse Json Now | **_mean 50,186.9 ns_** | **_Allocated 2312 B_**

