### PR TITLE
Load Xsd Schemas With Base Uri Set.

### DIFF
--- a/Src/src/Qart.Core/Xsd/XsdUtils.cs
+++ b/Src/src/Qart.Core/Xsd/XsdUtils.cs
@@ -13,10 +13,10 @@ namespace Qart.Core.Xsd
 
         public static XmlSchema Load(string path)
         {
-            using (var stream = FileUtils.OpenFileStreamForReading(path))
-            {
-                return Load(stream);
-            }
+            using var stream = new FileStream(path, FileMode.Open, FileAccess.Read);
+            using var reader = XmlReader.Create(Stream, null, path);
+
+            return XmlSchema.Read(reader, null);
         }
     }
 }


### PR DESCRIPTION
The current loader does not set the base URI on the schema when it is loaded. This means that when you try to resolve relative URIs in xsd includes, they will not be found.